### PR TITLE
Add numeric RiskSensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,19 +34,22 @@ You can install this custom component using [HACS](https://hacs.xyz/) by adding 
 ## Configuration
 The pollens integration is **now available in the Integration Menu**
 1. Select your county
-2. Untick the option to have numeric states or submit to stay with literal states
+2. Untick the option to have numeric states or submit to stay with literal states (for particular pollens sensors only)
 3. Select all the pollens you want to have in sensors
 
 You can also configure option to change default scan interval (3 hours)
 
 Old Pollens platform configuration **must be removed** from `configuration.yaml` file
 
-This will create one sensor ~~and severals attributes~~ :
+This will create 2 sensors :
 * sensor.pollens_*dept*
-  * attribution: Data from Reseau National de Surveillance Aerobiologique 
+  * value: global risk level for your county in **literal** state 
+  * url: https://pollens.fr
   * departement: *dept*
-  * *pollen* : *concentration*
 
-Sensors with particular Pollens like : 
+* sensor.pollens_*dept*_num
+  * value: global risk level for your county in **numeric** state (for graphs / gauges...)
+
+Sensors will also be created for selected particular Pollens : 
 Tilleul, Ambroisies, Olivier, Plantain, Noisetier, Aulne, Armoise, Châtaignier, Urticacées, Oseille, Graminées, Chêne, Platane, Bouleau, Charme, Peuplier, Frêne, Saule, Cyprès, Cupressacées.
-All sensors are named sensor.pollens_*dept*_*pollen-name*
+These sensors are named sensor.pollens_*dept*_*pollen-name*

--- a/custom_components/pollens/sensor.py
+++ b/custom_components/pollens/sensor.py
@@ -53,7 +53,10 @@ async def async_setup_entry(
     name = f"pollens_{coordinator.county}"
     icon = ICONS[0]
     sensors.append(
-        RiskSensor(coordinator=coordinator, name=name, icon=icon, entry=entry)
+        RiskSensor(coordinator=coordinator, name=name, icon=icon, entry=entry, numeric=False)
+    )
+    sensors.append(
+        RiskSensor(coordinator=coordinator, name=name + "_num", icon=icon, entry=entry, numeric=True)
     )
 
     async_add_entities(sensors, True)
@@ -120,17 +123,24 @@ class RiskSensor(PollensEntity, SensorEntity):
         name: str,
         icon: str,
         entry: ConfigEntry,
+        numeric: bool
     ) -> None:
         super().__init__(coordinator, name, icon, entry)
         self._risk_level = coordinator.api.risk_level
         self._attr_unique_id = f"{entry.entry_id}_{coordinator.county}"
         self._attr_icon = icon
         self._name = name
+        self._numeric = numeric
+        if numeric:
+            self._attr_unique_id += "_num"
 
     @property
     def native_value(self):
         value = self.coordinator.api.risk_level
-        return LIST_RISK[value]
+        if self._numeric:
+            return value
+        else:
+            return LIST_RISK[value]
 
     @property
     def icon(self):

--- a/custom_components/pollens/strings.json
+++ b/custom_components/pollens/strings.json
@@ -8,7 +8,7 @@
           "data": {
             "county": "[%key:common::config_flow::data::county%]",
             "scan_interval": "[%key:common::config_flow::data::scan_interval%]",
-            "literal_states":"[%key:common::config_flow::data::literal_states"
+            "literal_states":"[%key:common::config_flow::data::literal_states%]"
           }
         },
         "select_pollens": {
@@ -26,7 +26,7 @@
       },
       "abort": {
         "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-        "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed"
+        "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
       }
     },
     "options":{


### PR DESCRIPTION
Add a sensor named sensor.pollens_*dept*_num to have numeric state of global risk level.
Useful to integrate the value in graphs / gauges ...
![image](https://user-images.githubusercontent.com/38615348/180774325-c9f46df6-8be5-44eb-aa4f-c855d6d4fda5.png)

Does not impact previous sensor with literal state : no compatibility break
Fixe issue #9 