### PR TITLE
Risk level Compatible HomeKit

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![](https://img.shields.io/github/issues/chris60600/pollens-home-assistant)](https://github.com/chris60600/pollens-home-assistant/issues)
 [![](https://img.shields.io/github/manifest-json/v/chris60600/pollens-home-assistant?filename=custom_components%2Fpollens%2Fmanifest.json)](https://github.com/chris60600/pollens-home-assistant/)
 [![](https://img.shields.io/badge/Maintainer-%40chris60600-green)](https://github.com/chris60600)
+[![](https://img.shields.io/badge/Maintainer-%40chris60600-green)](https://github.com/swiipius)
 ![](https://img.shields.io/badge/Language-fr-green)
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg)](https://github.com/custom-components/hacs)
 

--- a/custom_components/pollens/pollensasync.py
+++ b/custom_components/pollens/pollensasync.py
@@ -45,7 +45,15 @@ class PollensClient:
             self._county_name = request_json["countyName"]
             for risk in request_json["risks"]:
                 self._risks[risk["pollenName"]] = risk["level"]
-            self._risk_level = request_json["riskLevel"]
+            r_level = request_json["riskLevel"]
+            if r_level == 0:
+               self._risk_level = 0
+            elif r_level == 1:
+               self._risk_level = 20
+            elif r_level == 2:
+               self._risk_level = 100
+            else:
+               self._risk_level = 200
             return request_json
         except (ClientError, asyncio.TimeoutError, ConnectionRefusedError) as err:
             return None

--- a/custom_components/pollens/sensor.py
+++ b/custom_components/pollens/sensor.py
@@ -28,9 +28,9 @@ _LOGGER = logging.getLogger(__name__)
 
 ICONS = {
     0: "mdi:decagram-outline",
-    1: "mdi:decagram-check",
-    2: "mdi:alert-decagram-outline",
-    3: "mdi:alert-decagram",
+    20: "mdi:decagram-check",
+    100: "mdi:alert-decagram-outline",
+    200: "mdi:alert-decagram",
 }
 
 

--- a/custom_components/pollens/sensor.py
+++ b/custom_components/pollens/sensor.py
@@ -140,7 +140,7 @@ class RiskSensor(PollensEntity, SensorEntity):
         self._numeric = numeric
         if numeric:
             self._attr_unique_id += "_risklevel"
-            self._attr_device_class = SensorDeviceClass.AQI
+            self._attr_device_class = SensorDeviceClass.GAS
             self._attr_state_class = SensorStateClass.MEASUREMENT
 
     @property


### PR DESCRIPTION
Hello,
I made some little tweaks to make the risk level to integrate in Homekit using HomeKit bridge. Just change sensor type to GAS. And to make it more readable I change the level, it seems to correspond with the pm2.5 level (values are arbitrary). Just open a PR for those who want to make it work cleanly in HomeKit.
![image0](https://github.com/chris60600/pollens-home-assistant/assets/70819571/089868c3-a8ed-4e2b-bb33-bc0794f5ca4e)
